### PR TITLE
Remove hamburger button gradient and duplicate chat button

### DIFF
--- a/app.js
+++ b/app.js
@@ -119,6 +119,9 @@ app.get('/', (req, res) => {
        font-size: 1.8rem;
        cursor: pointer;
        color: #333D4B;
+       background: none;
+       border: none;
+       padding: 0;
      }
      .menu.open { display: flex; }
     
@@ -528,7 +531,6 @@ app.get('/', (req, res) => {
           <a href="#pricing">가격</a>
           <a href="#reviews">고객후기</a>
           <a href="#faq">FAQ</a>
-          <a href="http://pf.kakao.com/_hxeQWn/chat" class="btn btn-primary" target="_blank">카카오톡 상담하기</a>
         </div>
         <button class="hamburger" id="menu-toggle" aria-label="메뉴 열기" aria-controls="primary-menu" aria-expanded="false">☰</button>
       </nav>

--- a/public/index.html
+++ b/public/index.html
@@ -108,6 +108,9 @@
       font-size: 1.8rem;
       cursor: pointer;
       color: #333D4B;
+      background: none;
+      border: none;
+      padding: 0;
     }
     
     /* Hero Section */
@@ -516,7 +519,6 @@
           <a href="#pricing">가격</a>
           <a href="#reviews">고객후기</a>
           <a href="#faq">FAQ</a>
-          <a href="http://pf.kakao.com/_hxeQWn/chat" class="btn btn-primary" target="_blank">카카오톡 상담하기</a>
         </div>
         <button class="hamburger" id="menu-toggle" aria-label="메뉴 열기" aria-controls="primary-menu" aria-expanded="false">☰</button>
       </nav>


### PR DESCRIPTION
Remove gradient background from mobile hamburger button and duplicate KakaoTalk consultation button from the menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3559e9d-ac8c-4f1d-a742-bf8c5b686401">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3559e9d-ac8c-4f1d-a742-bf8c5b686401">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

